### PR TITLE
Resolved bug for space issue 

### DIFF
--- a/Trappist/src/Promact.Trappist.Core/Controllers/TestController.cs
+++ b/Trappist/src/Promact.Trappist.Core/Controllers/TestController.cs
@@ -16,12 +16,13 @@ namespace Promact.Trappist.Core.Controllers
         {
             _testRepository = testRepository;
         }
+
+        #region Test
         /// <summary>
         /// this method is to verify unique name of a test
         /// </summary>
         /// <param name="testName">name of the test</param>
-        /// <returns>boolean</returns>
-
+        /// <returns>boolean</returns>        
         [HttpGet("isUnique/{testName}/{id}")]
         public async Task<bool> IsTestNameUnique([FromRoute] string testName, [FromRoute] int id)
         {
@@ -54,7 +55,8 @@ namespace Promact.Trappist.Core.Controllers
             var tests = await _testRepository.GetAllTestsAsync();
             return Ok(tests);
         }
-
+        #endregion 
+        #region Test Settings
         /// <summary>
         /// Gets the Settings saved for a particular Test
         /// </summary>
@@ -109,7 +111,8 @@ namespace Promact.Trappist.Core.Controllers
             else
                 return BadRequest();
         }
-
+        #endregion
+        #region Delete Test
         /// <summary>
         /// Check whether there is any test attendee or not
         /// </summary>
@@ -146,5 +149,6 @@ namespace Promact.Trappist.Core.Controllers
             await _testRepository.DeleteTestAsync(id);
             return NoContent();
         }
+        #endregion
     }
 }

--- a/Trappist/src/Promact.Trappist.Repository/Test/TestsRepository.cs
+++ b/Trappist/src/Promact.Trappist.Repository/Test/TestsRepository.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Promact.Trappist.Utility.GlobalUtil;
 using System;
+using Promact.Trappist.Utility.ExtensionMethods;
 
 namespace Promact.Trappist.Repository.Tests
 {
@@ -37,6 +38,7 @@ namespace Promact.Trappist.Repository.Tests
         /// <returns>boolean</returns>
         public async Task<bool> IsTestNameUniqueAsync(string testName, int id)
         {
+            testName = StringExtensions.AllTrim(testName);
             var isTestExists = await (_dbContext.Test.AnyAsync(x =>
                                     x.TestName.ToLowerInvariant() == testName.ToLowerInvariant()
                                     && x.Id != id));

--- a/Trappist/src/Promact.Trappist.Repository/Test/TestsRepository.cs
+++ b/Trappist/src/Promact.Trappist.Repository/Test/TestsRepository.cs
@@ -38,7 +38,7 @@ namespace Promact.Trappist.Repository.Tests
         /// <returns>boolean</returns>
         public async Task<bool> IsTestNameUniqueAsync(string testName, int id)
         {
-            testName = StringExtensions.AllTrim(testName);
+            testName = testName.AllTrim();
             var isTestExists = await (_dbContext.Test.AnyAsync(x =>
                                     x.TestName.ToLowerInvariant() == testName.ToLowerInvariant()
                                     && x.Id != id));

--- a/Trappist/src/Promact.Trappist.Repository/Test/TestsRepository.cs
+++ b/Trappist/src/Promact.Trappist.Repository/Test/TestsRepository.cs
@@ -19,13 +19,14 @@ namespace Promact.Trappist.Repository.Tests
             _dbContext = dbContext;
             _util = util;
         }
-
+        #region Test
         /// <summary>
         /// this method is used to create a new test
         /// </summary>
         /// <param name="test">object of Test</param>
         public async Task CreateTestAsync(Test test)
         {
+            test.TestName = test.TestName.AllTrim();
             test.Link = _util.GenerateRandomString(10);
             _dbContext.Test.Add(test);
             await _dbContext.SaveChangesAsync();
@@ -52,7 +53,8 @@ namespace Promact.Trappist.Repository.Tests
         {
             return await _dbContext.Test.OrderByDescending(x => x.CreatedDateTime).ToListAsync();
         }
-
+        #endregion
+        #region Test Settings
         /// <summary>
         /// Updates the edited Test Name
         /// </summary>
@@ -106,7 +108,8 @@ namespace Promact.Trappist.Repository.Tests
         {
             return await _dbContext.Test.AnyAsync(x => x.Id == id);
         }
-
+        #endregion
+        #region Delete Test
         public async Task<bool> IsTestAttendeeExistAsync(int id)
         {
             Test test = await _dbContext.Test.Include(x => x.TestAttendees).FirstOrDefaultAsync(x => x.Id == id);
@@ -119,5 +122,6 @@ namespace Promact.Trappist.Repository.Tests
             _dbContext.Test.Remove(test);
             await _dbContext.SaveChangesAsync();
         }
+        #endregion
     }
 }

--- a/Trappist/src/Promact.Trappist.Repository/Test/TestsRepository.cs
+++ b/Trappist/src/Promact.Trappist.Repository/Test/TestsRepository.cs
@@ -38,9 +38,8 @@ namespace Promact.Trappist.Repository.Tests
         /// <returns>boolean</returns>
         public async Task<bool> IsTestNameUniqueAsync(string testName, int id)
         {
-            testName = testName.AllTrim();
             var isTestExists = await (_dbContext.Test.AnyAsync(x =>
-                                    x.TestName.ToLowerInvariant() == testName.ToLowerInvariant()
+                                    x.TestName.ToLowerInvariant() == testName.AllTrim().ToLowerInvariant()
                                     && x.Id != id));
             return !isTestExists;
         }


### PR DESCRIPTION
…spaces

**Fixed Issues**

#21557

**Files Changed**

TestsRepository.cs- used StringExtensions.AllTrim() from utility to remove all leading, trailing and intermediate whitespace in test name

**Checks**

- [x] Naming Conventions
- [x] Server side code comments (proper English, grammar and no spelling mistakes)
- [x] Client side code comments (proper English, grammar and no spelling mistakes)
- [x] Unused variables, methods, blank spaces and namespaces. 
- [x] Optimal Code and code formatting
- [x] Commit History is proper, no merge is done. 
- [x] Commit/pull request messages should be proper to justify your feature
- [x] All test cases are executed provided by the tester.
