### PR TITLE
The default option for category dropdown will no longer be selectable

### DIFF
--- a/Trappist/src/Promact.Trappist.Web/wwwroot/app/questions/questions-programming/questions-programming.html
+++ b/Trappist/src/Promact.Trappist.Web/wwwroot/app/questions/questions-programming/questions-programming.html
@@ -13,7 +13,7 @@
                 <div class="form-group">
                     <label>Section</label>
                     <select class="form-control width-percent-60" id="categorySelect" (change)="selectCategory($event.target.value)" [(ngModel)]="selectedCategory" required name="categorySelect" #categorySelect="ngModel">
-                        <option [disabled]="categorySelect.dirty" default>Please select a Category</option>
+                        <option [disabled]="categorySelect.dirty || isQuestionEdited || isQuestionDuplicated" default>Please select a Category</option>
                         <option *ngFor="let category of categoryList">{{category.categoryName}}</option>
                     </select>
                     <div class="errors-container">


### PR DESCRIPTION
**Fixed Issues**

#21836

questions-programming.html - Added condition to disable default option in category drop down list.

**Checks**

- [x] Naming Conventions
- [ ] Server side code comments (proper English, grammar and no spelling mistakes)
- [ ] Client side code comments (proper English, grammar and no spelling mistakes)
- [x] Unused variables, methods, blank spaces and name spaces. 
- [x] Optimal Code and code formatting
- [x] Commit History is proper, no merge is done. 
- [x] Commit/pull request messages should be proper to justify your feature
- [ ] All test cases are executed provided by tester.

**Known Issues**

- No issue

**Comments**

NA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/promact/trappist/310)
<!-- Reviewable:end -->
