### PR TITLE
Solved bug related to updating valid test name on pressing enter.

### DIFF
--- a/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/shared/create-test-header/create-test-header.component.ts
+++ b/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/shared/create-test-header/create-test-header.component.ts
@@ -18,7 +18,6 @@ export class CreateTestHeaderComponent implements OnInit {
     testNameUpdatedMessage: string;
     isTestNameExist: boolean;
     testNameRef: string;
-    isEditButtonVisible: boolean;
     isLabelVisible: boolean;
     id: number;
     testName: string;
@@ -33,7 +32,6 @@ export class CreateTestHeaderComponent implements OnInit {
     constructor(private testService: TestService, private router: Router, private route: ActivatedRoute, private snackbarRef: MdSnackBar) {
         this.testNameUpdatedMessage = 'Test Name has been updated successfully';
         this.isTestNameExist = false;
-        this.isEditButtonVisible = true;
         this.isLabelVisible = true;
     }
 
@@ -66,7 +64,7 @@ export class CreateTestHeaderComponent implements OnInit {
      * Hides the edit button and makes the check and close buttons visible
      */
     hideEditButton() {
-        this.isEditButtonVisible = false;
+        //this.isEditButtonVisible = false;
         this.isLabelVisible = false;
         if (this.editedTestName) {
             this.testDetails.testName = this.editedTestName;
@@ -78,7 +76,6 @@ export class CreateTestHeaderComponent implements OnInit {
      * @param testName contains the value of the text box containing the Test name
      */
     showEditButton(testName: string) {
-        this.isEditButtonVisible = true;
         this.isLabelVisible = true;
         if (this.editedTestName)
             this.nameOfTest = this.editedTestName;
@@ -111,18 +108,29 @@ export class CreateTestHeaderComponent implements OnInit {
                         this.editedTestName = this.testName;
                         this.openSnackBar(this.testNameUpdatedMessage);
                         this.isLabelVisible = true;
-                        this.isEditButtonVisible = true;
-                    });
+                    },
+                        errorHandling => {
+                            this.openSnackBar('Something went wrong');
+                        });
                 }
                 else {
                     this.isTestNameExist = true;
                     this.isLabelVisible = false;
                 }
-            },
-            );
+            });
+
         }
         else
             this.isWhiteSpaceError = true;
+    }
+
+    /**
+     * On pressing the enter key the test name will be updated if test name is valid
+     * @param testName contains the test name 
+     */
+    onEnter(testName: string) {
+        if (testName)
+            this.updateTestName(this.testId, this.testDetails);
     }
 
     /**

--- a/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/shared/create-test-header/create-test-header.component.ts
+++ b/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/shared/create-test-header/create-test-header.component.ts
@@ -64,7 +64,6 @@ export class CreateTestHeaderComponent implements OnInit {
      * Hides the edit button and makes the check and close buttons visible
      */
     hideEditButton() {
-        //this.isEditButtonVisible = false;
         this.isLabelVisible = false;
         if (this.editedTestName) {
             this.testDetails.testName = this.editedTestName;

--- a/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/shared/create-test-header/create-test-header.component.ts
+++ b/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/shared/create-test-header/create-test-header.component.ts
@@ -118,7 +118,6 @@ export class CreateTestHeaderComponent implements OnInit {
                     this.isLabelVisible = false;
                 }
             });
-
         }
         else
             this.isWhiteSpaceError = true;

--- a/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/shared/create-test-header/create-test-header.html
+++ b/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/shared/create-test-header/create-test-header.html
@@ -1,19 +1,23 @@
 ﻿<div class="test-create-header clearfix">
   <div class="container">
     <h1 class="pull-left">
-      <span class="test-name" [hidden]="!isLabelVisible">{{testDetails.testName}}</span>
-      <input type="text" id="name" #box name="name" class="form-control" placeholder="Ex. Software Developer Recruitment Test" (keyup)="changeErrorMessage()"
-             [(ngModel)]="testDetails.testName" #name="ngModel" required pattern="^[a-zA-Z0-9_@ $#%&_*^{}[\]\|.?-]*$" maxlength="150" (focus)="selectAllContent($event)"
-             [hidden]="isLabelVisible"  (click)="$event.preventDefault()"/>
-      <button type="button" class="icon-btn ml10" (click)="hideEditButton()" *ngIf="isEditButtonVisible"><em class="material-icons">edit</em></button>
-      <span class="update-btns">
-        <button type="submit" class="icon-btn ml10" (click)="updateTestName(testDetails.id,testDetails)" *ngIf="!isEditButtonVisible" [disabled]="name.invalid || isTestNameExist"><em class="material-icons theme-text">check</em></button>
-        <button type="button" class="icon-btn ml10" (click)="showEditButton(box.value)" *ngIf="!isEditButtonVisible"><em class="material-icons danger-text">close</em></button>
+      <span [hidden]="!isLabelVisible">
+        <span class="test-name">{{testDetails.testName}}</span>
+        <button type="button" class="icon-btn ml10" (click)="hideEditButton()"><em class="material-icons">edit</em></button>
       </span>
-      <span class="errors-container">
-        <span class="error-msg" *ngIf="isWhiteSpaceError || name.errors && name.dirty && !name.valid && name.errors.required">Name is required</span>
-        <span class="error-msg" *ngIf="name.errors && (name. touched || name.untouched)  && !name.valid && name.errors.pattern && name.dirty">Enter a valid Test Name</span>
-        <span class="error-msg" *ngIf="isTestNameExist">Test with this name already exists</span>
+      <span [hidden]="isLabelVisible">
+        <input type="text" id="name" #box name="name" class="form-control" placeholder="Ex. Software Developer Recruitment Test" (keyup)="changeErrorMessage()"
+               [(ngModel)]="testDetails.testName" #name="ngModel" required pattern="^[a-zA-Z0-9_@ $#%&_*^{}[\]\|.?-]*$" maxlength="150" (focus)="selectAllContent($event)"
+               (click)="$event.preventDefault()" (keyup.enter)="onEnter(box.value)" />
+        <span class="update-btns">
+          <button type="submit" class="icon-btn ml10" (click)="updateTestName(testDetails.id,testDetails)" [disabled]="name.invalid || isTestNameExist"><em class="material-icons theme-text">check</em></button>
+          <button type="button" class="icon-btn ml10" (click)="showEditButton(box.value)"><em class="material-icons danger-text">close</em></button>
+        </span>
+        <span class="errors-container">
+          <span class="error-msg" *ngIf="isWhiteSpaceError || (name.dirty && !name.valid && name.errors.required)">Name is required</span>
+          <span class="error-msg" *ngIf="name.dirty && !name.valid && name.errors.pattern">Test name should be alphanumeric. Allowed special symbols are @, _ and white space</span>
+          <span class="error-msg" *ngIf="isTestNameExist">Test with this name already exists</span>
+        </span>
       </span>
     </h1>
     <button type="button" class="btn btn-primary pull-right"><em class="material-icons">remove_red_eye</em> Preview</button>


### PR DESCRIPTION
**Fixed Issues**
#22008

**Files Changed**
create-test-header.component.ts - Added method for updating valid test name on pressing enter and removed unused variable.
create-test-header.html-Made label,textbox and buttons visible with the help of a single boolean variable instead of two.

**Checks**

- [x] Naming Conventions
- [ ] Server side code comments (proper English, grammar and no spelling mistakes)
- [x] Client side code comments (proper English, grammar and no spelling mistakes)
- [x] Unused variables, methods, blank spaces and name spaces. 
- [x] Optimal Code and code formatting
- [x] Commit History is proper, no merge is done. 
- [x] Commit/pull request messages should be proper to justify your feature
- [x] All test cases are executed provided by tester.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/promact/trappist/354)
<!-- Reviewable:end -->
