### PR TITLE
Start and End Test Date Fields Validation on blur event.

### DIFF
--- a/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/test-settings/test-settings.html
+++ b/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/test-settings/test-settings.html
@@ -1,122 +1,122 @@
 ﻿<div class="test-create-steps test-settings">
-    <div class="loader-container" *ngIf="loader">
-        <div class="spinner"></div>
-    </div>
-    <form #settingsForm="ngForm">
-        <create-test-header [disablePreview]="disablePreview" [testDetails]="testDetails" [testNameReference]="testNameReference"></create-test-header>
-        <div class="container">
-            <h5>Settings & Schedule</h5>
-            <div class="form-area">
-                <fieldset [disabled]="showIsPausedButton && !testDetails.isPaused">
-                    <div class="form-group">
-                        <label>Time Duration (mins)</label><em class="danger-text h4">*</em>
-                        <input type="text" class="form-control small-width" [(ngModel)]="testDetails.duration" name="Duration" placeholder="00" #Duration="ngModel" required pattern="^(0*[1-9])\d{0,3}?$" (keyup)="isWarningTimeValid()" />
-                        <div class="errors-container">
-                            <span class="error-msg" *ngIf="Duration.errors && Duration.dirty && !Duration.valid && Duration.errors.required">Required</span>
-                            <span class="error-msg" *ngIf="Duration.errors && Duration.dirty && !Duration.valid && Duration.errors.pattern">Invalid Time</span>
-                        </div>
-                    </div>
-                    <div class="form-group inline-field">
-                        <label>Start Date & Time</label>
-                        <input type="datetime-local" class="form-control small-width" [(ngModel)]="testDetails.startDate" name="Start Date" (mouseup)="isStartDateValid()" (keyup)="isStartDateValid()" />
-                        <div class="errors-container">
-                            <span class="error-msg small-width" *ngIf="validStartDate">Start DateTime must be greater than current DateTime.</span>
-                        </div>
-                    </div>
-                    <div class="form-group inline-field">
-                        <label>End Date & Time</label>
-                        <input type="datetime-local" class="form-control small-width" [(ngModel)]="testDetails.endDate" name="End Date" (mouseup)="isEndDateValid(testDetails.endDate)" (keyup)="isEndDateValid(testDetails.endDate)" />
-                        <div class="errors-container">
-                            <span class="error-msg" *ngIf="validEndDate">End DateTime must be greater than start DateTime.</span>
-                        </div>
-                    </div>
-                  <div class="form-group ip-restrictions">
-                    <label>IP Restrictions</label>
-                    <div class="ip-add-field" *ngFor="let ip of testDetails.testIpAddress; let i= index">
-                      <input type="text" class="form-control small-width" id="From" name="ip_{{i}}" placeholder="IP Address {{i+1}}" (keyup)="IpAddressAdded(ip.ipAddress);showErrorMessage(ip)" (focus)="IpAddressAdded(ip.ipAddress)" #From=ngModel [(ngModel)]="ip.ipAddress" pattern="^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$" />
-                      <em class="material-icons" (click)="removeIpAddress(i,ip.id,ip.ipAddress)">close</em>
-                      <div class="errors-container">
-                        <span class="error-msg" *ngIf="From.errors && From.dirty" [hidden]="!From.errors.pattern">Enter IP address in correct format.</span>
-                        <span class="error-msg" *ngIf="ip.isErrorMessageVisible">Add IP Address or remove this field.</span>
-                      </div>
-                    </div>
-                    <button md-mini-fab type="button" [disabled]="showIsPausedButton && !testDetails.isPaused || !isIpAddressAdded" (click)="addIpFields()"><md-icon>add</md-icon></button>
-                  </div>
-                    <div class="form-group">
-                        <label>Browser Tolerance</label>
-                        <select class="form-control half-width" [(ngModel)]="testDetails.browserTolerance" name="Browser Tolerance">
-                            <option value="0">Not Applicable</option>
-                            <option value="12">Low</option>
-                            <option value="7">Medium</option>
-                            <option value="3">High</option>
-                        </select>
-                        <div class="errors-container"></div>
-                    </div>
-                    <div class="form-group" *ngIf="testDetails.browserTolerance != 0">
-                        <label>Focus Lost Time (secs)</label>
-                        <input type="text" pattern="[0-9]*" class="form-control small-width" placeholder="00" [(ngModel)]="testDetails.focusLostTime" name="FocusLostTime" min="0" #FocusLostTime="ngModel" />
-                        <div class="errors-container">
-                            <span class="error-msg" *ngIf="FocusLostTime.errors && FocusLostTime.dirty && !FocusLostTime.valid && FocusLostTime.errors.pattern">Invalid Time</span>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label>Question Order</label>
-                        <select class="form-control half-width" [(ngModel)]="testDetails.questionOrder" name="questionOrder">
-                            <option value="0">Fixed</option>
-                            <option value="1">Random</option>
-                        </select>
-                        <div class="errors-container"></div>
-                    </div>
-                    <div class="form-group">
-                        <label>Option Order</label>
-                        <select class="form-control half-width" [(ngModel)]="testDetails.optionOrder" name="optionOrder">
-                            <option value="0">Fixed</option>
-                            <option value="1">Random</option>
-                        </select>
-                        <div class="errors-container"></div>
-                    </div>
-                    <div class="form-group inline-field">
-                        <label>Correct Marks</label><em class="danger-text h4">*</em>
-                        <input type="text" class="form-control small-width" [(ngModel)]="testDetails.correctMarks" name="CorrectMarks" #CorrectMarks="ngModel" required pattern="^(0*[1-9])\d{0,3}(\.{1}\d{1,2})?$" min="0" />
-                        <div class="errors-container">
-                            <span class="error-msg" *ngIf="CorrectMarks.errors && CorrectMarks.dirty && !CorrectMarks.valid && CorrectMarks.errors.required">Required</span>
-                            <span class="error-msg" *ngIf="CorrectMarks.errors && CorrectMarks.dirty && !CorrectMarks.valid && CorrectMarks.errors.pattern">Enter valid correct marks.</span>
-                        </div>
-                    </div>
-                    <div class="form-group inline-field">
-                        <label>Incorrect Marks</label><em class="danger-text h4">*</em>
-                        <input type="text" class="form-control small-width" [(ngModel)]="testDetails.incorrectMarks" name="IncorrectMarks" #IncorrectMarks="ngModel" required pattern="^\d{0,3}(\.\d{1,2})?$" min="0" />
-                        <div class="errors-container">
-                            <span class="error-msg" *ngIf="IncorrectMarks.errors && IncorrectMarks.dirty && !IncorrectMarks.valid && IncorrectMarks.errors.required">Required</span>
-                            <span class="error-msg" *ngIf="IncorrectMarks.errors && IncorrectMarks.dirty && !IncorrectMarks.valid && IncorrectMarks.errors.pattern">Enter valid incorrect marks.</span>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label>Allow Test Resume</label>
-                        <select class="form-control half-width" [(ngModel)]="testDetails.allowTestResume" name="allowTestResume">
-                            <option value="0">Supervised</option>
-                            <option value="1">Unsupervised</option>
-                        </select>
-                        <div class="errors-container"></div>
-                    </div>
-                    <div class="form-group">
-                        <label>Warning Message</label>
-                        <textarea class="form-control half-width" rows="3" #textarea placeholder="Your message here" [(ngModel)]="testDetails.warningMessage" name="Warning Message" maxlength="255"></textarea>
-                        <div class="errors-container"></div>
-                    </div>
-                    <div class="form-group">
-                        <label>Warning Time (mins)</label>
-                        <input type="text" pattern="[0-9]*" class="form-control small-width" placeholder="00" [(ngModel)]="testDetails.warningTime" name="WarningTime" min="0" #WarningTime="ngModel" (keyup)="isWarningTimeValid()" />
-                        <div class="errors-container">
-                            <span class="error-msg" *ngIf="WarningTime.errors && WarningTime.dirty && !WarningTime.valid && WarningTime.errors.pattern">Invalid Time</span>
-                            <span class="error-msg" *ngIf="validTime">Warning time should be less than time duration.</span>
-                        </div>
-                    </div>
-
-                </fieldset>
-                <create-test-footer [loader]="!loader" [showIsPausedButton]="showIsPausedButton" [isRelaunched]="isRelaunched" [testDetails]="testDetails" (saveTestSettings)="saveTestSettings(testDetails.id,testDetails)" (launchTestDialog)="launchTestDialog(testDetails.id,testDetails,$event)" (pauseTest)="pauseTest()" (resumeTest)="resumeTest()" [settingsForm]="settingsForm" [validStartDate]="validStartDate" [validEndDate]="validEndDate" [validTime]="validTime" [isIpAddressAdded]="isIpAddressAdded"></create-test-footer>
+  <div class="loader-container" *ngIf="loader">
+    <div class="spinner"></div>
+  </div>
+  <form #settingsForm="ngForm">
+    <create-test-header [disablePreview]="disablePreview" [testDetails]="testDetails" [testNameReference]="testNameReference"></create-test-header>
+    <div class="container">
+      <h5>Settings & Schedule</h5>
+      <div class="form-area">
+        <fieldset [disabled]="showIsPausedButton && !testDetails.isPaused">
+          <div class="form-group">
+            <label>Time Duration (mins)</label><em class="danger-text h4">*</em>
+            <input type="text" class="form-control small-width" [(ngModel)]="testDetails.duration" name="Duration" placeholder="00" #Duration="ngModel" required pattern="^(0*[1-9])\d{0,3}?$" (keyup)="isWarningTimeValid()" />
+            <div class="errors-container">
+              <span class="error-msg" *ngIf="Duration.errors && Duration.dirty && !Duration.valid && Duration.errors.required">Required</span>
+              <span class="error-msg" *ngIf="Duration.errors && Duration.dirty && !Duration.valid && Duration.errors.pattern">Invalid Time</span>
             </div>
-        </div>
-    </form>
+          </div>
+          <div class="form-group inline-field">
+            <label>Start Date & Time</label>
+            <input type="datetime-local" class="form-control small-width" [(ngModel)]="testDetails.startDate" name="Start Date" (mouseup)="isStartDateValid()" (keyup)="isStartDateValid()" (blur)="isStartDateValid()" />
+            <div class="errors-container">
+              <span class="error-msg small-width" *ngIf="validStartDate">Start DateTime must be greater than current DateTime.</span>
+            </div>
+          </div>
+          <div class="form-group inline-field">
+            <label>End Date & Time</label>
+            <input type="datetime-local" class="form-control small-width" [(ngModel)]="testDetails.endDate" name="End Date" (mouseup)="isEndDateValid(testDetails.endDate)" (keyup)="isEndDateValid(testDetails.endDate)" (blur)="isEndDateValid(testDetails.endDate)" />
+            <div class="errors-container">
+              <span class="error-msg" *ngIf="validEndDate">End DateTime must be greater than start DateTime.</span>
+            </div>
+          </div>
+          <div class="form-group ip-restrictions">
+            <label>IP Restrictions</label>
+            <div class="ip-add-field" *ngFor="let ip of testDetails.testIpAddress; let i= index">
+              <input type="text" class="form-control small-width" id="From" name="ip_{{i}}" placeholder="IP Address {{i+1}}" (keyup)="IpAddressAdded(ip.ipAddress);showErrorMessage(ip)" (focus)="IpAddressAdded(ip.ipAddress)" #From=ngModel [(ngModel)]="ip.ipAddress" pattern="^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$" />
+              <em class="material-icons" (click)="removeIpAddress(i,ip.id,ip.ipAddress)">close</em>
+              <div class="errors-container">
+                <span class="error-msg" *ngIf="From.errors && From.dirty" [hidden]="!From.errors.pattern">Enter IP address in correct format.</span>
+                <span class="error-msg" *ngIf="ip.isErrorMessageVisible">Add IP Address or remove this field.</span>
+              </div>
+            </div>
+            <button md-mini-fab type="button" [disabled]="showIsPausedButton && !testDetails.isPaused || !isIpAddressAdded" (click)="addIpFields()"><md-icon>add</md-icon></button>
+          </div>
+          <div class="form-group">
+            <label>Browser Tolerance</label>
+            <select class="form-control half-width" [(ngModel)]="testDetails.browserTolerance" name="Browser Tolerance">
+              <option value="0">Not Applicable</option>
+              <option value="12">Low</option>
+              <option value="7">Medium</option>
+              <option value="3">High</option>
+            </select>
+            <div class="errors-container"></div>
+          </div>
+          <div class="form-group" *ngIf="testDetails.browserTolerance != 0">
+            <label>Focus Lost Time (secs)</label>
+            <input type="text" pattern="[0-9]*" class="form-control small-width" placeholder="00" [(ngModel)]="testDetails.focusLostTime" name="FocusLostTime" min="0" #FocusLostTime="ngModel" />
+            <div class="errors-container">
+              <span class="error-msg" *ngIf="FocusLostTime.errors && FocusLostTime.dirty && !FocusLostTime.valid && FocusLostTime.errors.pattern">Invalid Time</span>
+            </div>
+          </div>
+          <div class="form-group">
+            <label>Question Order</label>
+            <select class="form-control half-width" [(ngModel)]="testDetails.questionOrder" name="questionOrder">
+              <option value="0">Fixed</option>
+              <option value="1">Random</option>
+            </select>
+            <div class="errors-container"></div>
+          </div>
+          <div class="form-group">
+            <label>Option Order</label>
+            <select class="form-control half-width" [(ngModel)]="testDetails.optionOrder" name="optionOrder">
+              <option value="0">Fixed</option>
+              <option value="1">Random</option>
+            </select>
+            <div class="errors-container"></div>
+          </div>
+          <div class="form-group inline-field">
+            <label>Correct Marks</label><em class="danger-text h4">*</em>
+            <input type="text" class="form-control small-width" [(ngModel)]="testDetails.correctMarks" name="CorrectMarks" #CorrectMarks="ngModel" required pattern="^(0*[1-9])\d{0,3}(\.{1}\d{1,2})?$" min="0" />
+            <div class="errors-container">
+              <span class="error-msg" *ngIf="CorrectMarks.errors && CorrectMarks.dirty && !CorrectMarks.valid && CorrectMarks.errors.required">Required</span>
+              <span class="error-msg" *ngIf="CorrectMarks.errors && CorrectMarks.dirty && !CorrectMarks.valid && CorrectMarks.errors.pattern">Enter valid correct marks.</span>
+            </div>
+          </div>
+          <div class="form-group inline-field">
+            <label>Incorrect Marks</label><em class="danger-text h4">*</em>
+            <input type="text" class="form-control small-width" [(ngModel)]="testDetails.incorrectMarks" name="IncorrectMarks" #IncorrectMarks="ngModel" required pattern="^\d{0,3}(\.\d{1,2})?$" min="0" />
+            <div class="errors-container">
+              <span class="error-msg" *ngIf="IncorrectMarks.errors && IncorrectMarks.dirty && !IncorrectMarks.valid && IncorrectMarks.errors.required">Required</span>
+              <span class="error-msg" *ngIf="IncorrectMarks.errors && IncorrectMarks.dirty && !IncorrectMarks.valid && IncorrectMarks.errors.pattern">Enter valid incorrect marks.</span>
+            </div>
+          </div>
+          <div class="form-group">
+            <label>Allow Test Resume</label>
+            <select class="form-control half-width" [(ngModel)]="testDetails.allowTestResume" name="allowTestResume">
+              <option value="0">Supervised</option>
+              <option value="1">Unsupervised</option>
+            </select>
+            <div class="errors-container"></div>
+          </div>
+          <div class="form-group">
+            <label>Warning Message</label>
+            <textarea class="form-control half-width" rows="3" #textarea placeholder="Your message here" [(ngModel)]="testDetails.warningMessage" name="Warning Message" maxlength="255"></textarea>
+            <div class="errors-container"></div>
+          </div>
+          <div class="form-group">
+            <label>Warning Time (mins)</label>
+            <input type="text" pattern="[0-9]*" class="form-control small-width" placeholder="00" [(ngModel)]="testDetails.warningTime" name="WarningTime" min="0" #WarningTime="ngModel" (keyup)="isWarningTimeValid()" />
+            <div class="errors-container">
+              <span class="error-msg" *ngIf="WarningTime.errors && WarningTime.dirty && !WarningTime.valid && WarningTime.errors.pattern">Invalid Time</span>
+              <span class="error-msg" *ngIf="validTime">Warning time should be less than time duration.</span>
+            </div>
+          </div>
+
+        </fieldset>
+        <create-test-footer [loader]="!loader" [showIsPausedButton]="showIsPausedButton" [isRelaunched]="isRelaunched" [testDetails]="testDetails" (saveTestSettings)="saveTestSettings(testDetails.id,testDetails)" (launchTestDialog)="launchTestDialog(testDetails.id,testDetails,$event)" (pauseTest)="pauseTest()" (resumeTest)="resumeTest()" [settingsForm]="settingsForm" [validStartDate]="validStartDate" [validEndDate]="validEndDate" [validTime]="validTime" [isIpAddressAdded]="isIpAddressAdded"></create-test-footer>
+      </div>
+    </div>
+  </form>
 
 </div>


### PR DESCRIPTION

**Fixed Issues**

#23718- Added code for checking the validity of start and end test date fields of test settings page on blur event.

**Files Changed**

test-settings.html-Added blur event in start and end test fields of test settings page for firing the validations of these two fields.

**Checks**

- [x] Naming Conventions
- [x] Server side code comments (proper English, grammar and no spelling mistakes)
- [x] Client side code comments (proper English, grammar and no spelling mistakes)
- [x] Unused variables, methods, blank spaces and name spaces. 
- [x] Optimal Code and code formatting
- [x] Commit History is proper, no merge is done. 
- [x] Commit/pull request messages should be proper to justify your feature
- [x] All test cases are executed provided by tester.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/promact/trappist/499)
<!-- Reviewable:end -->
