### PR TITLE
Solved the issue of format being displayed instead of selected dates in start and end date fields of test settings page.

### DIFF
--- a/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/test-settings/test-settings.component.ts
+++ b/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/test-settings/test-settings.component.ts
@@ -186,10 +186,7 @@ export class TestSettingsComponent implements OnInit {
      * @param testObject is an object of class Test
      */
     launchTestDialog(id: number, testObject: Test, isTestLaunched: boolean) {
-
-        testObject.startDate = new Date(<string>testObject.startDate).toISOString();
-        testObject.endDate = new Date(<string>testObject.endDate).toISOString();
-
+        
         let isCategoryAdded = this.testDetails.categoryAcList.some(x => {
             return x.isSelect;
         });
@@ -201,6 +198,8 @@ export class TestSettingsComponent implements OnInit {
                 this.testDetails.isLaunched = true;
                 this.isRelaunched = new Date(<string>this.testDetails.startDate).getTime() > Date.now() && this.testDetails.isLaunched;
                 this.showIsPausedButton = new Date(<string>this.testDetails.startDate).getTime() <= Date.now() && this.testDetails.isLaunched;
+                testObject.startDate = new Date(<string>testObject.startDate).toISOString();
+                testObject.endDate = new Date(<string>testObject.endDate).toISOString();
                 this.testService.updateTestById(id, testObject).subscribe((response) => {
                     this.ngOnInit();
                     this.openSnackBar('Your test has been launched successfully.');


### PR DESCRIPTION

**Fixed Issues**

#23936

**Files Changed**

test-settings.component.ts-Added code for displaying the selected date and time for start and end date fields instead of date format on closing the incomplete test creation dialog box without selecting any questions or sections.

**Checks**

- [x] Naming Conventions
- [x] Server side code comments (proper English, grammar and no spelling mistakes)
- [x] Client side code comments (proper English, grammar and no spelling mistakes)
- [x] Unused variables, methods, blank spaces and name spaces. 
- [x] Optimal Code and code formatting
- [x] Commit History is proper, no merge is done. 
- [x] Commit/pull request messages should be proper to justify your feature
- [x] All test cases are executed provided by tester.

**Known Issues**

- issue 1
- issue 2

**Comments**

anything that you want to convey about this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/promact/trappist/518)
<!-- Reviewable:end -->
