### PR TITLE
hide generatereportbutton when all reports are generated

### DIFF
--- a/Trappist/src/Promact.Trappist.Web/wwwroot/app/reports/test-report/test-report.component.ts
+++ b/Trappist/src/Promact.Trappist.Web/wwwroot/app/reports/test-report/test-report.component.ts
@@ -293,12 +293,12 @@ export class TestReportComponent implements OnInit {
                     this.noCandidateFound = false;
                 break;
             case 4:
-                this.showGenerateReportButton = true;
                 starAttendeeArray.forEach(x => {
                     if (x.report.testStatus === TestStatus.allCandidates || x.report.testStatus === TestStatus.unfinishedTest) {
                         tempAttendeeArray.push(x);
                     }
                 });
+                this.showGenerateReportButton = tempAttendeeArray.some(x => x.report.totalMarksScored === null);
                 if (tempAttendeeArray.length === 0)
                     this.noCandidateFound = true;
                 else
@@ -794,6 +794,7 @@ export class TestReportComponent implements OnInit {
                 });
 
                 this.isGeneratingReport = false;
+                this.showGenerateReportButton = this.testAttendeeArray.some(x => x.report.totalMarksScored === null);
             });
         }
     }


### PR DESCRIPTION
**Fixed Issues**

#23933 i.e when all reports generated for unfinished test ,'GenerateReport' button is made hidden 

**Files Changed**

test.report.component.ts

**Checks**

- [ ] Naming Conventions
- [x] Server side code comments (proper English, grammar and no spelling mistakes)
- [ ] Client side code comments (proper English, grammar and no spelling mistakes)
- [ ] Unused variables, methods, blank spaces and name spaces. 
- [ ] Optimal Code and code formatting
- [ ] Commit History is proper, no merge is done. 
- [ ] Commit/pull request messages should be proper to justify your feature
- [ ] All test cases are executed provided by tester.

**Known Issues**

- issue 1
- issue 2

**Comments**

anything that you want to convey about this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/promact/trappist/528)
<!-- Reviewable:end -->
