### PR TITLE
Open dialog containing instructions about common code mistakes automatically.

### DIFF
--- a/Trappist/src/Promact.Trappist.Web/wwwroot/app/conduct/test/test.component.ts
+++ b/Trappist/src/Promact.Trappist.Web/wwwroot/app/conduct/test/test.component.ts
@@ -75,6 +75,7 @@ export class TestComponent implements OnInit {
     isConnectionLoss: boolean;
     isConnectionRetrieved: boolean;
     clearTime: any;
+    count: number;
 
     private seconds: number;
     private focusLost: number;
@@ -134,6 +135,7 @@ export class TestComponent implements OnInit {
         this.isCodeProcessing = false;
         this.url = window.location.pathname;
         this.isInitializing = true;
+        this.count = 0;
     }
 
     ngOnInit() {
@@ -522,6 +524,7 @@ export class TestComponent implements OnInit {
                 solution.code.result = this.codeResult;
                 this.testAnswers.push(solution);
                 this.isCodeProcessing = false;
+                this.openDialog(codeResponse.message, codeResponse.error);
             }, err => {
                 this.codeResult = 'Oops! Server error has occured.';
                 this.isCodeProcessing = false;
@@ -720,7 +723,6 @@ export class TestComponent implements OnInit {
         } else if (this.codeResult.toLowerCase().includes('processing')) {
             return '';
         }
-
         return 'fail';
     }
 
@@ -904,4 +906,27 @@ export class TestComponent implements OnInit {
             this.router.navigate(routeTo);
         }
     }
+
+    /**
+     * Opens TestsProgrammingGuideDialogComponent automatically when an attendee fails to pass the test cases consecutively for a number of times
+     * @param message contains the information whether test cases have passed or failed
+     * @param errorMessage contains the informaion whether there is any syntax errors
+     */
+    openDialog(message: string, errorMessage: string) {
+        if (message != null) {
+            if (message.toLowerCase().includes('congratulation')) 
+                this.count = 0;
+            else if (message.toLowerCase().includes('some') || message.toLowerCase().includes('none')) {
+                this.count = this.count + 1;
+            }
+        }
+        else if (errorMessage != null)
+            this.count = this.count + 1;
+        if (this.count === 5) {
+            this.dialog.open(TestsProgrammingGuideDialogComponent, { disableClose: true, hasBackdrop: true });
+            this.count = 0;
+        }
+    }
 }
+
+

--- a/Trappist/src/Promact.Trappist.Web/wwwroot/app/conduct/test/test.component.ts
+++ b/Trappist/src/Promact.Trappist.Web/wwwroot/app/conduct/test/test.component.ts
@@ -913,14 +913,14 @@ export class TestComponent implements OnInit {
      * @param errorMessage contains the informaion whether there is any syntax errors
      */
     openDialog(message: string, errorMessage: string) {
-        if (message != null) {
+        if (message !== null) {
             if (message.toLowerCase().includes('congratulation')) 
                 this.count = 0;
             else if (message.toLowerCase().includes('some') || message.toLowerCase().includes('none')) {
                 this.count = this.count + 1;
             }
         }
-        else if (errorMessage != null)
+        else if (errorMessage !== null)
             this.count = this.count + 1;
         if (this.count === 5) {
             this.dialog.open(TestsProgrammingGuideDialogComponent, { disableClose: true, hasBackdrop: true });

--- a/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/test-questions/test-questions.component.ts
+++ b/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/test-questions/test-questions.component.ts
@@ -274,7 +274,8 @@ export class TestQuestionsComponent implements OnInit {
      */
     openDialog(category: Category, k: number): void {
         let dialogRef = this.dialog.open(RandomQuestionSelectionDialogComponent, {
-            data: { numberOfQuestions: category.numberOfRandomQuestionsSelected, numberOfQuestionsInSelectedCategory: category.questionList.length }
+            data: { numberOfQuestions: category.numberOfRandomQuestionsSelected, numberOfQuestionsInSelectedCategory: category.questionList.length },
+            disableClose: true, hasBackdrop: true 
         });
 
         dialogRef.afterClosed().subscribe(result => {

--- a/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/test-settings/test-launch-dialog.component.ts
+++ b/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/test-settings/test-launch-dialog.component.ts
@@ -21,6 +21,10 @@ export class RandomQuestionSelectionDialogComponent implements OnInit {
 
     ngOnInit() { }
 
+    /**
+     * Checks whether the number of questions to be selected randomly is lesser or greater than the number of questions present in the selected category
+     * @param numberOfQuestionsToBeSelectedRandomly contains the number of questions entered for selecting randomly
+     */
     isNumberOfQuestionsEnteredValid(numberOfQuestionsToBeSelectedRandomly: number) {
         this.isErrorMessageVisible = +numberOfQuestionsToBeSelectedRandomly > this.data.numberOfQuestionsInSelectedCategory;
         this.isPatternMismatched = !(/^[0-9]*$/.test(numberOfQuestionsToBeSelectedRandomly.toString()));

--- a/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/test-settings/test-launch-dialog.html
+++ b/Trappist/src/Promact.Trappist.Web/wwwroot/app/tests/test-settings/test-launch-dialog.html
@@ -10,8 +10,8 @@
         <input type="text" class="form-control" [(ngModel)]="data.numberOfQuestions" required pattern="^[0-9]*$" name="noOfQuestions" #noOfQuestions="ngModel" (keyup)="isNumberOfQuestionsEnteredValid(data.numberOfQuestions)"/>
         <div class="errors-container">
           <span class="error-msg" *ngIf="noOfQuestions.dirty && !noOfQuestions.valid && noOfQuestions.errors.required">Required</span>
-          <span class="error-msg" *ngIf="noOfQuestions.dirty && !noOfQuestions.valid && noOfQuestions.errors.pattern">You are allowed to enter integer values.</span>
-          <span class="error-msg" *ngIf="isErrorMessageVisible && !isPatternMismatched">Number of questions must be less than the number of questions present in the selected category.</span>
+          <span class="error-msg" *ngIf="noOfQuestions.dirty && !noOfQuestions.valid && noOfQuestions.errors.pattern">You are allowed to enter integer values without space.</span>
+          <span class="error-msg" *ngIf="isErrorMessageVisible && !isPatternMismatched">Number of questions entered must be less than the number of questions present in the selected category.</span>
         </div>
       </div>
     </md-dialog-content>


### PR DESCRIPTION
**Fixed Issues**

#24122

**Files Changed**

test.component.ts-Added code for opening the dialog box containing the instructions related to common code mistakes when the test attendee fails to pass the test cases on attempting 5 consecutive times.
test-questions.component.ts-Added code for preventing closing of dialog box on blur.
test-launch-dialog.component.ts-Added comments for the method written.
test-launch-dialog.html-Modified the validation messages for number of questions to be selected.

**Checks**

- [x] Naming Conventions
- [x] Server side code comments (proper English, grammar and no spelling mistakes)
- [x] Client side code comments (proper English, grammar and no spelling mistakes)
- [x] Unused variables, methods, blank spaces and name spaces. 
- [x] Optimal Code and code formatting
- [x] Commit History is proper, no merge is done. 
- [x] Commit/pull request messages should be proper to justify your feature
- [x] All test cases are executed provided by tester.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/promact/trappist/543)
<!-- Reviewable:end -->
